### PR TITLE
docs: pin explicit anchors on two headings with awkward slugs

### DIFF
--- a/docs/IncRem-Scheduler.md
+++ b/docs/IncRem-Scheduler.md
@@ -51,7 +51,7 @@ With the default scheduler:
 
 ---
 
-## Beta Scheduler — Saturating Curve ✨
+## Beta Scheduler — Saturating Curve ✨ { #beta-scheduler }
 
 > Enable this via **Settings → Use Beta Scheduler (Saturating Curve)**.
 

--- a/docs/Utilities.md
+++ b/docs/Utilities.md
@@ -14,7 +14,7 @@ The two new powerups — **Remove Parent** and **Remove Grandparent** — are al
 
 ---
 
-## Hide in Queue (`hiq`)
+## Hide in Queue (`hiq`) { #hide-in-queue }
 
 Tag any Rem with **Hide in Queue** (using the command). Its content will be replaced on the front of descendant flashcards with "Hidden in queue":
 


### PR DESCRIPTION
'## Beta Scheduler — Saturating Curve ✨' and '## Hide in Queue (`hiq`)' contain punctuation whose generated slug is hard to predict — an em dash plus an emoji, and backticks plus parentheses. Explicit ids make them linkable with certainty from outside the docs (the plugin's in-app settings help links point here).

attr_list is already enabled and nothing referenced the generated ids, so no rendered text changes and no existing link breaks.

### Summary 🎯

<!-- Please explain the purpose, and **link** any relevant issues-->

### Changes 🔁

-
